### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.3.0",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,6 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
+import rateLimit from "express-rate-limit";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
@@ -76,10 +77,18 @@ export function serveStatic(app: Express) {
     );
   }
 
+  // set up rate limiter: maximum 100 requests per 15 minutes per IP
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
+  app.use(limiter);
+
   app.use(express.static(distPath));
 
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", limiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/bitnunblockchain-ux/BitnunEco/security/code-scanning/2](https://github.com/bitnunblockchain-ux/BitnunEco/security/code-scanning/2)

To fix the issue, we should apply a rate limiting middleware to the static file-serving routes in `serveStatic`, particularly to the catch-all `"*"` route handler and preferably also to `express.static`. The standard way is to use a popular middleware, such as `express-rate-limit`. This involves importing the package, instantiating a limiter (with reasonable request limits, e.g., 100 per 15 minutes), and applying it before the static route handlers. In this case, edits should be made only within `server/vite.ts` by:

1. Requiring (importing) `express-rate-limit`.
2. Instantiating the limiter.
3. Applying `app.use(limiter);` immediately before the static serving routes within `serveStatic`.

All changes must be done in `server/vite.ts`, and only additions—no removals of existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
